### PR TITLE
Drop docs preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           cd test/
           cargo fmt --all --check
 
-  docs:
+  test-docs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -102,13 +102,3 @@ jobs:
         run: |
           cargo doc --all --no-deps
           echo '<meta http-equiv="refresh" content="0; url=rmathlib">' > target/doc/index.html
-
-      # Not using actions/deploy-pages because it crashes for some reason.
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        if: github.ref == 'refs/heads/main'
-        with:
-          cname: 'rmathlib.poweranalyses.org'
-          force_orphan: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: './target/doc'

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 A Rust port of [R's C Library of Special Functions](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#The-standalone-Rmath-library).
 
-[![][docs-latest-img]][docs-latest-url]
-
-[docs-latest-img]: https://img.shields.io/badge/docs-preview-blue.svg
-[docs-latest-url]: https://rmathlib.poweranalyses.org
-
 ## Benefits
 
 Some benefits of this port over the native C code are:


### PR DESCRIPTION
The preview is mostly confusing, so let's only use <https://docs.rs/rmathlib>.